### PR TITLE
Add timeout parameter to device connection

### DIFF
--- a/alpaca/camera.py
+++ b/alpaca/camera.py
@@ -165,6 +165,7 @@ class Camera(Device):
         address: str,
         device_number: int,
         protocol: str = "http",
+        defaulttimeout: float = 5.0
     ):
         """Initialize the Camera object
 
@@ -172,9 +173,10 @@ class Camera(Device):
             address (str): IP address and port of the device (x.x.x.x:pppp)
             device_number (int): The index of the device (usually 0)
             protocol (str, optional): Only if device needs https. Defaults to "http".
+            defaulttimeout: Default timeout for this device connection. Default to 5.0 seconds.
 
         """
-        super().__init__(address, "camera", device_number, protocol)
+        super().__init__(address, "camera", device_number, protocol, defaulttimeout)
         self.img_desc = None
 
     @property

--- a/alpaca/covercalibrator.py
+++ b/alpaca/covercalibrator.py
@@ -71,7 +71,8 @@ class CoverCalibrator(Device):
         self,
         address: str,
         device_number: int,
-        protocol: str = "http"
+        protocol: str = "http",
+        defaulttimeout: float = 5.0
     ):
         """Initialize CoverCalibrator object.
 
@@ -79,9 +80,10 @@ class CoverCalibrator(Device):
             address (str): IP address and port of the device (x.x.x.x:pppp)
             device_number (int): The index of the device (usually 0)
             protocol (str, optional): Only if device needs https. Defaults to "http".
+            defaulttimeout: Default timeout for this device connection. Default to 5.0 seconds.
 
         """
-        super().__init__(address, "covercalibrator", device_number, protocol)
+        super().__init__(address, "covercalibrator", device_number, protocol, defaulttimeout)
 
     @property
     def Brightness(self) -> int:

--- a/alpaca/device.py
+++ b/alpaca/device.py
@@ -68,7 +68,8 @@ class Device:
         address: str,
         device_type: str,
         device_number: int,
-        protocol: str
+        protocol: str,
+        defaulttimeout: float = 5.0
     ):
         """Initialize Device object.
 
@@ -83,6 +84,7 @@ class Device:
             protocol: Protocol (http vs https) used to communicate with Alpaca server.
             api_version: Alpaca API version.
             base_url: Basic URL to easily append with commands.
+            defaulttimeout: Default timeout for this device connection. Default to 5.0 seconds.
 
         Note:
             * Sets a random number for ClientID that lasts
@@ -93,6 +95,7 @@ class Device:
         self.device_type = device_type.lower()
         self.device_number = device_number
         self.api_version = API_VERSION
+        self.defaulttimeout = defaulttimeout
         self.base_url = "%s://%s/api/v%d/%s/%d" % (
             protocol,       # not needed later
             self.address,
@@ -883,15 +886,17 @@ class Device:
 # HTTP/JSON Communications
 # ========================
 
-    def _get(self, attribute: str, tmo=5.0, **data) -> str:
+    def _get(self, attribute: str, tmo=-1, **data) -> str:
         """Send an HTTP GET request to an Alpaca server and check response for errors.
 
         Args:
             attribute (str): Attribute to get from server.
-            tmo (optional) Timeout for HTTP (default = 5 sec)
+            tmo (optional) Timeout for HTTP (default = 5 sec or set at init)
             **data: Data to send with request.
 
         """
+        if (tmo==-1):
+          tmo = self.defaulttimeout
         # Make Host: header safe for IPv6
         if(self.address.startswith('[') and not self.address.startswith('[::1]')):
             hdrs = {'Host': f'{self.address.split("%")[0]}]'}
@@ -913,15 +918,17 @@ class Device:
         self.__check_error(response)
         return response.json()["Value"]
 
-    def _put(self, attribute: str, tmo=5.0, **data) -> str:
+    def _put(self, attribute: str, tmo=-1, **data) -> str:
         """Send an HTTP PUT request to an Alpaca server and check response for errors.
 
         Args:
             attribute (str): Attribute to put to server.
-            tmo (optional) Timeout for HTTP (default = 5 sec)
+            tmo (optional) Timeout for HTTP (default = 5 sec or set at init)
             **data: Data to send with request.
 
         """
+        if (tmo==-1):
+          tmo = self.defaulttimeout
         # Make Host: header safe for IPv6
         if(self.address.startswith('[') and not self.address.startswith('[::1]')):
             hdrs = {'Host': f'{self.address.split("%")[0]}]'}

--- a/alpaca/dome.py
+++ b/alpaca/dome.py
@@ -61,7 +61,8 @@ class Dome(Device):
         self,
         address: str,
         device_number: int,
-        protocol: str = "http"
+        protocol: str = "http",
+        defaulttimeout: float = 5.0
     ):
         """Initialize Dome object.
 
@@ -69,12 +70,13 @@ class Dome(Device):
             address (str): IP address and port of the device (x.x.x.x:pppp)
             device_number (int): The index of the device (usually 0)
             protocol (str, optional): Only if device needs https. Defaults to "http".
+            defaulttimeout: Default timeout for this device connection. Default to 5.0 seconds.
 
         Raises:
             DriverException: An error occurred that is not described by one of the more specific ASCOM exceptions. The device did not *successfully* complete the request.
 
         """
-        super().__init__(address, "dome", device_number, protocol)
+        super().__init__(address, "dome", device_number, protocol, defaulttimeout)
 
     @property
     def Altitude(self) -> float:

--- a/alpaca/filterwheel.py
+++ b/alpaca/filterwheel.py
@@ -51,7 +51,8 @@ class FilterWheel(Device):
         self,
         address: str,
         device_number: int,
-        protocol: str = "http"
+        protocol: str = "http",
+        defaulttimeout: float = 5.0
     ):
         """Initialize FilterWheel object.
 
@@ -59,9 +60,10 @@ class FilterWheel(Device):
             address (str): IP address and port of the device (x.x.x.x:pppp)
             device_number (int): The index of the device (usually 0)
             protocol (str, optional): Only if device needs https. Defaults to "http".
+            defaulttimeout: Default timeout for this device connection. Default to 5.0 seconds.
 
         """
-        super().__init__(address, "filterwheel", device_number, protocol)
+        super().__init__(address, "filterwheel", device_number, protocol, defaulttimeout)
 
     @property
     def FocusOffsets(self) -> List[int]:

--- a/alpaca/focuser.py
+++ b/alpaca/focuser.py
@@ -59,7 +59,8 @@ class Focuser(Device):
         self,
         address: str,
         device_number: int,
-        protocol: str = "http"
+        protocol: str = "http",
+        defaulttimeout: float = 5.0
     ):
         """Initialize Focuser object.
 
@@ -67,9 +68,10 @@ class Focuser(Device):
             address (str): IP address and port of the device (x.x.x.x:pppp)
             device_number (int): The index of the device (usually 0)
             protocol (str, optional): Only if device needs https. Defaults to "http".
+            defaulttimeout: Default timeout for this device connection. Default to 5.0 seconds.
 
         """
-        super().__init__(address, "focuser", device_number, protocol)
+        super().__init__(address, "focuser", device_number, protocol, defaulttimeout)
 
 
     @property

--- a/alpaca/observingconditions.py
+++ b/alpaca/observingconditions.py
@@ -59,7 +59,8 @@ class ObservingConditions(Device):
         self,
         address: str,
         device_number: int,
-        protocol: str = "http"
+        protocol: str = "http",
+        defaulttimeout: float = 5.0
     ):
         """Initialize the ObservingConditions object.
 
@@ -67,9 +68,10 @@ class ObservingConditions(Device):
             address (str): IP address and port of the device (x.x.x.x:pppp)
             device_number (int): The index of the device (usually 0)
             protocol (str, optional): Only if device needs https. Defaults to "http".
+            defaulttimeout: Default timeout for this device connection. Default to 5.0 seconds.
 
         """
-        super().__init__(address, "observingconditions", device_number, protocol)
+        super().__init__(address, "observingconditions", device_number, protocol, defaulttimeout)
 
     @property
     def AveragePeriod(self) -> float:

--- a/alpaca/rotator.py
+++ b/alpaca/rotator.py
@@ -53,7 +53,8 @@ class Rotator(Device):
         self,
         address: str,
         device_number: int,
-        protocol: str = "http"
+        protocol: str = "http",
+        defaulttimeout: float = 5.0
     ):
         """Initialize the Rotator object.
 
@@ -61,12 +62,13 @@ class Rotator(Device):
             address (str): IP address and port of the device (x.x.x.x:pppp)
             device_number (int): The index of the device (usually 0)
             protocol (str, optional): Only if device needs https. Defaults to "http".
+            defaulttimeout: Default timeout for this device connection. Default to 5.0 seconds.
 
         Raises:
             DriverException: An error occurred that is not described by one of the more specific ASCOM exceptions. The device did not *successfully* complete the request.
 
         """
-        super().__init__(address, "rotator", device_number, protocol)
+        super().__init__(address, "rotator", device_number, protocol, defaulttimeout)
 
     @property
     def CanReverse(self) -> bool:

--- a/alpaca/safetymonitor.py
+++ b/alpaca/safetymonitor.py
@@ -57,7 +57,8 @@ class SafetyMonitor(Device):
         self,
         address: str,
         device_number: int,
-        protocol: str = "http"
+        protocol: str = "http",
+        defaulttimeout: float = 5.0
     ):
         """Initialize the SafetyMonitor object.
 
@@ -65,9 +66,10 @@ class SafetyMonitor(Device):
             address (str): IP address and port of the device (x.x.x.x:pppp)
             device_number (int): The index of the device (usually 0)
             protocol (str, optional): Only if device needs https. Defaults to "http".
+            defaulttimeout: Default timeout for this device connection. Default to 5.0 seconds.
 
         """
-        super().__init__(address, "safetymonitor", device_number, protocol)
+        super().__init__(address, "safetymonitor", device_number, protocol, defaulttimeout)
 
     @property
     def IsSafe(self) -> bool:

--- a/alpaca/switch.py
+++ b/alpaca/switch.py
@@ -54,7 +54,8 @@ class Switch(Device):
         self,
         address: str,
         device_number: int,
-        protocol: str = "http"
+        protocol: str = "http",
+        defaulttimeout: float = 5.0
     ):
         """Initialize the Switch device.
 
@@ -62,9 +63,10 @@ class Switch(Device):
             address (str): IP address and port of the device (x.x.x.x:pppp)
             device_number (int): The index of the device (usually 0)
             protocol (str, optional): Only if device needs https. Defaults to "http".
+            defaulttimeout: Default timeout for this device connection. Default to 5.0 seconds.
 
         """
-        super().__init__(address, "switch", device_number, protocol)
+        super().__init__(address, "switch", device_number, protocol, defaulttimeout)
 
     @property
     def MaxSwitch(self) -> int:

--- a/alpaca/telescope.py
+++ b/alpaca/telescope.py
@@ -119,7 +119,8 @@ class Telescope(Device):
         self,
         address: str,
         device_number: int,
-        protocol: str = "http"
+        protocol: str = "http",
+        defaulttimeout: float = 5.0
     ):
         """Initialize the Telescope object.
 
@@ -127,12 +128,13 @@ class Telescope(Device):
             address (str): IP address and port of the device (x.x.x.x:pppp)
             device_number (int): The index of the device (usually 0)
             protocol (str, optional): Only if device needs https. Defaults to "http".
+            defaulttimeout: Default timeout for this device connection. Default to 5.0 seconds.
 
         Raises:
             DriverException: An error occurred that is not described by one of the more specific ASCOM exceptions. The device did not *successfully* complete the request.
 
         """
-        super().__init__(address, "telescope", device_number, protocol)
+        super().__init__(address, "telescope", device_number, protocol, defaulttimeout)
 
     @property
     def AlignmentMode(self) -> AlignmentModes:


### PR DESCRIPTION
Hi @BobDenny ,

The default alpyca http timeout of 5 seconds is not enough in some specific case. 
This include using old, non async driver with Ascom Remote.
To address this case we need a timeout parameter when creating an instance of the Alpaca client.

This PR add the parameter so for the device that need it we can do:
T = Telescope('localhost:11111', 0, 'http', 30)    # use 30 second timeout
while this format still use the default of 5 seconds:
T = Telescope('localhost:11111', 0)

This is probably the less intrusive way to do it despite not all the method do require the long timeout, but it can be very complicated to use a configurable different timeout for every method.

I see in the code that only Telescope.FindHome use a specific timeout of 60 seconds, this is not modified by this change, it still use 60 seconds as specified in the _put() call.

Patrick
 