### PR TITLE
Fix typo in camera docs sample code

### DIFF
--- a/docs/source/alpaca.camera.rst
+++ b/docs/source/alpaca.camera.rst
@@ -128,7 +128,7 @@ acquire a short image, download and make a local FITS file::
         pass
     try:
         hdr['OFFSET'] = c.Offset
-        if type(c.Offset == int):
+        if type(c.Offset) == int:
             hdr['PEDESTAL'] = c.Offset
     except:
         pass


### PR DESCRIPTION
Currently there's a line that reads:

```
if type(c.Offset == int):
```

Presumably this was meant to be:

```
if type(c.Offset) == int:
```