### PR TITLE
Fix driverinfo retrieval to handle empty cases

### DIFF
--- a/alpaca/device.py
+++ b/alpaca/device.py
@@ -705,7 +705,7 @@ class Device:
                 there.
 
         """
-        return [i.strip() for i in self._get("driverinfo").split(",")]
+        return [i.strip() for i in self._get("driverinfo", "").split(",")]
 
     @property
     def DriverVersion(self) -> str:


### PR DESCRIPTION
First, many thanks for this nice package. I move completely to this solution recently in my application.
 
I interface with NINA (as they offer all devices as ALPACA devices through a plugin).
In case of some devices they are not filling the device.info field. The conformance checker does not raise an issue about it.

If there is no field populated, get will return NONE. From implementation this could happen.
If doing a split to none, python raises an exception. This could be corrected by giving a default value of an empty string.

If an empty device.info is right or incorrect I do not address, simply only the robustness of the python implementation.

Michel

